### PR TITLE
fix(auth): fix login logic when a user types a wrong or right password

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -69,22 +69,23 @@ export class AuthService {
           data: { message: 'Invalid e-mail or password' },
         };
       }
-      user.accessAttempt = 0;
-      await this.userRepository.updateUser(user);
-
-      delete user.password;
-      delete user.code;
-      delete user.emailConfirmed;
-      delete user.deleted;
-      delete user.accessAttempt;
-
-      return {
-        status: 200,
-        data: {
-          token: this.jwt.sign({ email }),
-          user,
-        },
-      };
     }
+
+    user.accessAttempt = 0;
+    await this.userRepository.updateUser(user);
+
+    delete user.password;
+    delete user.code;
+    delete user.emailConfirmed;
+    delete user.deleted;
+    delete user.accessAttempt;
+
+    return {
+      status: 200,
+      data: {
+        token: this.jwt.sign({ email }),
+        user,
+      },
+    };
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -69,7 +69,6 @@ export class AuthService {
           data: { message: 'Invalid e-mail or password' },
         };
       }
-
       user.accessAttempt = 0;
       await this.userRepository.updateUser(user);
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -69,23 +69,23 @@ export class AuthService {
           data: { message: 'Invalid e-mail or password' },
         };
       }
-
-      user.accessAttempt = 0;
-      await this.userRepository.updateUser(user);
-
-      delete user.password;
-      delete user.code;
-      delete user.emailConfirmed;
-      delete user.deleted;
-      delete user.accessAttempt;
-
-      return {
-        status: 200,
-        data: {
-          token: this.jwt.sign({ email }),
-          user,
-        },
-      };
     }
+
+    user.accessAttempt = 0;
+    await this.userRepository.updateUser(user);
+
+    delete user.password;
+    delete user.code;
+    delete user.emailConfirmed;
+    delete user.deleted;
+    delete user.accessAttempt;
+
+    return {
+      status: 200,
+      data: {
+        token: this.jwt.sign({ email }),
+        user,
+      },
+    };
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -69,23 +69,23 @@ export class AuthService {
           data: { message: 'Invalid e-mail or password' },
         };
       }
+
+      user.accessAttempt = 0;
+      await this.userRepository.updateUser(user);
+
+      delete user.password;
+      delete user.code;
+      delete user.emailConfirmed;
+      delete user.deleted;
+      delete user.accessAttempt;
+
+      return {
+        status: 200,
+        data: {
+          token: this.jwt.sign({ email }),
+          user,
+        },
+      };
     }
-
-    user.accessAttempt = 0;
-    await this.userRepository.updateUser(user);
-
-    delete user.password;
-    delete user.code;
-    delete user.emailConfirmed;
-    delete user.deleted;
-    delete user.accessAttempt;
-
-    return {
-      status: 200,
-      data: {
-        token: this.jwt.sign({ email }),
-        user,
-      },
-    };
   }
 }


### PR DESCRIPTION
This commit fix an error in login's logic, the user was only able to login successfully if it provided a wrong password. This happened because the part of the code that accepted the login was inside an if to check invalid passwords. Thus, if a user tried the right password it would cause an internal server error.