### PR TITLE
fix: modificado extensao da logo do email que quebra no gmail se for svg

### DIFF
--- a/src/modules/mails/templates/confirmEmail.hbs
+++ b/src/modules/mails/templates/confirmEmail.hbs
@@ -15,7 +15,7 @@
 				<table class="container" cellpadding="0" cellspacing="0" border="0" style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh; width: 100vw;">
 					<tr>
 						<td align="center" valign="top">
-							<img src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506394/souJunior/vbcechsuw9gb0sihb8oi.svg" alt="logo SouJunior" style="max-width: 100%;" />
+							<img src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506394/souJunior/vbcechsuw9gb0sihb8oi.png" alt="logo SouJunior" style="max-width: 100%;" />
 						</td>
 					</tr>
 					<tr>

--- a/src/modules/mails/templates/restoreEmail.hbs
+++ b/src/modules/mails/templates/restoreEmail.hbs
@@ -15,7 +15,7 @@
 				<table class="container" cellpadding="0" cellspacing="0" border="0" style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh; width: 100vw;">
 					<tr>
 						<td align="center" valign="top">
-							<img src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506394/souJunior/vbcechsuw9gb0sihb8oi.svg" alt="logo SouJunior" style="max-width: 100%;" />
+							<img src="https://res.cloudinary.com/dja1rct0m/image/upload/v1705506394/souJunior/vbcechsuw9gb0sihb8oi.png" alt="logo SouJunior" style="max-width: 100%;" />
 						</td>
 					</tr>
                     <tr>


### PR DESCRIPTION
O gmail não aceita SVG e por isso a logo vem quebrada no email. Troquei para PNG.