### PR TITLE
add: alterando o código do login para reenviar o email de confirmação após uma tentativa de login onde a conta ainda não foi confirmada

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
     } else {
       info = await this.userRepository.findUserByEmail(email)
     }
-     this.infoConfirm(info, type);
+    await this.infoConfirm(info, type);
     
     const passwordIsValid = await bcrypt.compare(password, info.password);
 
@@ -68,9 +68,9 @@ export class AuthService {
 
       const message = 'Your account is not activated yet. Check your e-mail inbox for instructions'
 
-      if(type == 'mentor') await this.mailService.mentorSendCreationConfirmation(info as MentorEntity);
-      if(type == 'user') await this.mailService.userSendCreationConfirmation(info as UserEntity);
-
+      if(type == 'mentor') await this.mailService.mentorSendCreationConfirmation(info as MentorEntity)
+      if(type == 'user') await this.mailService.userSendCreationConfirmation(info as UserEntity)
+      
       throw new HttpException({ message }, HttpStatus.NOT_FOUND)
 
     }


### PR DESCRIPTION
Alteração feita conforme pedido do pessoal do front.
Eles pediram para alterar o código para que o e-mail de confirmação da conta fosse reenviado caso a pessoa estiver tentando fazer um login sem antes ter confirmado o primeiro e-mail.
Motivo do pedido: problema ao perder o primeiro email e depois não conseguir logar mais.