### PR TITLE
Now the project can start using "npm run start"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ COPY --from=builder /user/app/dist ./dist
 
 EXPOSE 3000
 
+ENV DATABASE_URL=${DATABASE_URL}
 CMD ["npm","run","start:prod"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,35 @@ dentro dela tem um:
 secure: true,
 ```
 
+## DevOps
+
+```mermaid
+sequenceDiagram
+    actor Dev as Desenvolvedores
+    participant Git as GitHub
+    participant Actions as GitHub Actions
+    participant ECR as AWS ECR
+
+    Dev->>Git: Abre Pull Request (PR) para main
+    Git->>Actions: Novo Evento: PR criada
+    Actions-->>Git: Cria imagem Docker
+    
+    Note over Dev,ECR: Loop de desenvolvimento
+    
+    Dev->>Git: Aprova e mergeia PR para main
+    Git->>Actions: Novo Evento: Branch main atualizada
+    activate Actions
+    par "Docker Image CI" workflow
+        Actions-->>Git: Cria imagem Docker
+    and "Docker Image CI for AWS" workflow
+        Actions->>Actions: Cria imagem Docker
+        Actions->>ECR: Atualiza imagem Docker em AWS ECR
+        ECR-->>Actions: Imagem Docker atualizada em AWS ECR
+        Actions-->>Git: Deploy de Produção atualizado
+    end
+    deactivate Actions
+```
+
 ![image](https://github.com/wendesongomes/mentores-backend/assets/82889172/0386598d-5053-4189-9e9b-e7d1a4ef1655)
 
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ secure: true,
 
 ## DevOps
 
+> [!WARNING]
+> GitHub workflow de CI sendo executado ao fazer push para main, duplicando validação que foi feita na PR antes do merge
+
+> [!TIP]
+> Atualizar "Docker Image CI" workflow, removendo "on: push: branches: [main]"
+
 ```mermaid
 sequenceDiagram
     actor Dev as Desenvolvedores

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ dentro dela tem um:
 secure: true,
 ```
 
+![image](https://github.com/wendesongomes/mentores-backend/assets/82889172/0386598d-5053-4189-9e9b-e7d1a4ef1655)
+
+
+troque para false, com isso o mailtrap vai capturar seus emails normalmente.
+
 ## DevOps
 
 > [!WARNING]
@@ -100,8 +105,3 @@ sequenceDiagram
     end
     deactivate Actions
 ```
-
-![image](https://github.com/wendesongomes/mentores-backend/assets/82889172/0386598d-5053-4189-9e9b-e7d1a4ef1655)
-
-
-troque para false, com isso o mailtrap vai capturar seus emails normalmente.


### PR DESCRIPTION
Before the project was only initialized using the command "npm run dev", cause it has many small errors that needed to be fixed. These errors are now fixed.